### PR TITLE
Fix toolbar actions

### DIFF
--- a/view/frontend/web/js/elasticsuite-ajax.js
+++ b/view/frontend/web/js/elasticsuite-ajax.js
@@ -105,22 +105,22 @@ define([
             let self = this;
 
             $(document).on('click', self.options.modeControl, function (e) {
-                self.updateLayer(self.current_href, 'product_list_mode', $(e.currentTarget).data('value'));
+                self.updateLayer(window.location.href, 'product_list_mode', $(e.currentTarget).data('value'));
                 e.preventDefault();
             });
 
             $(document).on('click', self.options.limitControl, function (e) {
-                self.updateLayer(self.current_href, 'product_list_limit', e.currentTarget.options[e.currentTarget.selectedIndex].value);
+                self.updateLayer(window.location.href, 'product_list_limit', e.currentTarget.options[e.currentTarget.selectedIndex].value);
                 e.preventDefault();
             });
 
             $(document).on('click', self.options.directionControl, function (e) {
-                self.updateLayer(self.current_href, 'product_list_dir', $(e.currentTarget).data('value'));
+                self.updateLayer(window.location.href, 'product_list_dir', $(e.currentTarget).data('value'));
                 e.preventDefault();
             });
 
             $(document).on('change', self.options.orderControl, function (e) {
-                self.updateLayer(self.current_href, 'product_list_order', e.currentTarget.options[e.currentTarget.selectedIndex].value);
+                self.updateLayer(window.location.href, 'product_list_order', e.currentTarget.options[e.currentTarget.selectedIndex].value);
                 e.preventDefault();
             });
 


### PR DESCRIPTION
Toolbar actions generated wrong parameters in url. 
[this.current_href](https://github.com/Web200/magento2-elasticsuite-ajax/blob/e9fdcb3056e3616f4c5184269ce8088634aaeef1/view/frontend/web/js/elasticsuite-ajax.js#L40) only set at widget init and all later toolbar actions delete parameters from url.